### PR TITLE
added support for Swift to check for sim runtime

### DIFF
--- a/ios/Plugin/UIDeviceJailBroken.swift
+++ b/ios/Plugin/UIDeviceJailBroken.swift
@@ -11,7 +11,11 @@ import UIKit
 
 extension UIDevice {
     var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
     }
 
     var isDebuggedMode: Bool {


### PR DESCRIPTION
Starting Apr/1/2025, this check is starting to fail with the following error:

/Users/MYNAME/Documents/APP/node_modules/@evehr/capacitor-jailbreak-root-detection/ios/Plugin/UIDeviceJailBroken.swift:14:16 Cannot find 'TARGET_OS_SIMULATOR' in scope